### PR TITLE
Fix tox envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py37,py38,py39,py310
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
So tox was skipping both py36 and py310