### PR TITLE
Make CLI arguments accessible in zxpy programs

### DIFF
--- a/tests/test_files/argv.py
+++ b/tests/test_files/argv.py
@@ -1,4 +1,8 @@
 import sys
 
-assert len(sys.argv) == 1
-assert sys.argv[0] == "foobar"
+assert len(sys.argv) == 3
+assert sys.argv[1] == "foobar"
+assert sys.argv[2] == "baz"
+
+out = ~"echo $1 and $2"
+assert out == "foobar and baz\n"

--- a/tests/test_files/argv.py
+++ b/tests/test_files/argv.py
@@ -1,4 +1,4 @@
 import sys
 
 assert len(sys.argv) == 1
-assert sys.argv[0].endswith("argv.py")
+assert sys.argv[0] == "foobar"

--- a/tests/test_files/injection.py
+++ b/tests/test_files/injection.py
@@ -1,0 +1,6 @@
+x = ~"uname -p"
+print(x in ("arm\n", "x86_64\n"))
+
+command = "uname -p"
+_, _, rc = ~f"{command}"  # This doesn't work
+print(rc)

--- a/tests/zxpy_test.py
+++ b/tests/zxpy_test.py
@@ -79,7 +79,7 @@ def test_prints(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_argv() -> None:
     test_file = "./tests/test_files/argv.py"
-    subprocess.run(["zxpy", test_file])
+    subprocess.check_call(["zxpy", test_file, "--", "foobar"])
 
 
 def test_raise() -> None:

--- a/tests/zxpy_test.py
+++ b/tests/zxpy_test.py
@@ -79,7 +79,8 @@ def test_prints(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_argv() -> None:
     test_file = "./tests/test_files/argv.py"
-    subprocess.check_call(["zxpy", test_file, "--", "foobar"])
+    returncode = subprocess.check_call(["zxpy", test_file, "--", "foobar"])
+    assert returncode == 0
 
 
 def test_raise() -> None:

--- a/zx.py
+++ b/zx.py
@@ -64,10 +64,19 @@ def cli() -> None:
     )
     parser.add_argument('filename', help='Name of file to run', nargs='?')
 
+    # Everything passed after a `--` is arguments to be used by the script itself.
+    try:
+        separator_index = sys.argv.index('--')
+        script_args = sys.argv[separator_index + 1 :]
+        # Remove everything after -- so that argparse passes
+        sys.argv = sys.argv[:separator_index]
+    except ValueError:
+        script_args = []
+
     args = parser.parse_args(namespace=ZxpyArgs())
 
-    # Remove zxpy executable from argv
-    del sys.argv[0]
+    # Once arg parsing is done, replace argv with script args
+    sys.argv = script_args
 
     if args.filename is None:
         setup_zxpy_repl()

--- a/zx.py
+++ b/zx.py
@@ -67,14 +67,15 @@ def cli() -> None:
     parser.add_argument('filename', help='Name of file to run', nargs='?')
 
     # Everything passed after a `--` is arguments to be used by the script itself.
+    script_args = ['/bin/sh']
     try:
         separator_index = sys.argv.index('--')
-        script_args = ['/bin/sh'] + sys.argv[separator_index + 1 :]
+        script_args.extend(sys.argv[separator_index + 1 :])
         # Remove everything after `--` so that argparse passes
         sys.argv = sys.argv[:separator_index]
     except ValueError:
-        # `--` not present in command
-        script_args = []
+        # `--` not present in command, so no extra script args
+        pass
 
     args = parser.parse_args(namespace=ZxpyArgs())
 

--- a/zx.py
+++ b/zx.py
@@ -104,7 +104,7 @@ def cli() -> None:
             install()
 
 
-def is_inside_single_quotes(string, index):
+def is_inside_single_quotes(string: str, index: int) -> bool:
     """Returns True if the given index is inside single quotes in a shell command."""
     quote_index = string.find("'")
     if quote_index == -1:


### PR DESCRIPTION
Allow passing arguments to CLI applications made with `zxpy`, by appending them after a `--`.

For example:

```python
#!/usr/bin/env zxpy

import sys
print("Argv is:", sys.argv)

~"echo output: $1 $2 $3"
```

```console
$ ./test.py           
Argv is: ['/bin/sh']
output:

$ ./test.py -- abc def
Argv is: ['/bin/sh', 'abc', 'def']
output: abc def
```

Resolves #50
